### PR TITLE
fix: prevent rebuild hang

### DIFF
--- a/src/lib/bundle/index.ts
+++ b/src/lib/bundle/index.ts
@@ -52,7 +52,15 @@ function ensureWorker() {
   return bundleWorker;
 }
 
+function resetWorker(error: Error) {
+  rejectPendingRequests(error);
+  bundleWorker?.terminate();
+  bundleWorker = null;
+}
+
 export async function bundle(files: SourceFile[], version: string): Promise<BundleResult> {
+  resetWorker(new Error("Bundle request superseded by a newer request"));
+
   const worker = ensureWorker();
   const id = nextRequestId++;
 


### PR DESCRIPTION
## Root Cause
Browser instrumentation narrowed the hang to the second compile inside a reused bundler worker. The first request completes, but on rebuild the worker reaches `rspack(options, callback)` and the callback never fires, so the main thread keeps waiting and the UI remains on `Bundling...`.

The trigger is the shared `@rspack/browser` `builtinMemFs.volume.reset()` call in the reused worker. In controlled browser runs:

- original path with `volume.reset()` reaches `core rspack start` on request 1 and never logs the callback
- explicit `compiler.run()` without `compiler.close()` still hangs when `volume.reset()` is kept, so `compiler.close()` is not the root cause
- keeping the original `rspack(options, callback)` path but skipping `volume.reset()` lets request 1 finish normally in the same worker

That points to the global in-worker memfs state used by `@rspack/browser`: resetting the shared volume after one compile can wedge the next native build. A fresh worker avoids reusing that corrupted shared runtime/memfs state.

## Summary
- terminate the current bundler worker before starting a new bundle request
- reject any pending request as superseded so stale rebuilds do not keep UI state alive
- create a fresh worker for the next compile, avoiding reuse of the `@rspack/browser` worker state after memfs reset

## Verification
- Browser: clean Chrome profile at `http://127.0.0.1:3000/`; initial build completed, then 6 rapid real keyboard edits in Monaco briefly showed `Bundling...` and recovered to `173ms` with output present
- Root-cause browser instrumentation:
  - with `volume.reset()`: request 1 reached `core rspack start` and did not callback within 10s
  - with `compiler.run()` no-close and `volume.reset()`: request 1 reached `core compiler.run start no-close` and did not callback within 10s
  - with original `rspack(options, callback)` and reset skipped: request 1 logged `core rspack callback ok` and `bundle done 1`, UI recovered to `78ms`
- pnpm lint:check
- pnpm format:check
- pnpm build