### PR TITLE
fix: use latest Rspack version by default

### DIFF
--- a/src/store/version.ts
+++ b/src/store/version.ts
@@ -179,9 +179,8 @@ const defaultRspackVersionAtom = atom(async (get) => {
 
   return (
     (initialVersion && !isDeprecatedRspackVersion(initialVersion) ? initialVersion : undefined) ??
-    (versions.includes(rspackBrowserPackage.version)
-      ? rspackBrowserPackage.version
-      : (versions[0] ?? ""))
+    versions[0] ??
+    getSafeInitRspackVersion()
   );
 });
 


### PR DESCRIPTION
## Summary

This PR changes the playground default Rspack version selection so fresh visits use the latest stable `@rspack/browser` version returned by npm registry metadata, while shared URLs continue to honor the encoded version. The bundled local package version now only acts as a fallback when registry data is unavailable.