### PR TITLE
fix: resolve remote rspack browser split chunk imports

### DIFF
--- a/src/lib/bundle/core.ts
+++ b/src/lib/bundle/core.ts
@@ -160,6 +160,19 @@ function replaceRequiredImportSource(
   );
 }
 
+function replaceRemoteRspackRelativeImportSources(source: string, version: string) {
+  return source.replace(
+    /\b(from\s*|import\s*)["'](\.\/[^"']+\.(?:mjs|js))["'];?/g,
+    (match, prefix: string, specifier: string) => {
+      try {
+        return `${prefix}${JSON.stringify(getRspackBrowserFileUrl(version, `dist/${specifier.slice(2)}`))};`;
+      } catch {
+        return match;
+      }
+    },
+  );
+}
+
 function hasImportSource(source: string, specifier: string) {
   return new RegExp(`from\\s*["']${escapeRegExp(specifier)}["'];?`).test(source);
 }
@@ -301,6 +314,7 @@ async function getRspackBrowserEntryUrls(version: string): Promise<RspackBrowser
       getJsdelivrEsmUrl("@rspack/lite-tapable", liteTapableVersion),
       "@rspack/lite-tapable import",
     );
+    rewrittenEntrySource = replaceRemoteRspackRelativeImportSources(rewrittenEntrySource, version);
 
     return {
       entryModuleUrl: createBlobModuleUrl(rewrittenEntrySource),


### PR DESCRIPTION
## Summary

- Fix loading `@rspack/browser@2.0.6` when its `dist/index.js` imports split chunks such as `./612.js`
- Rewrite remaining relative `./*.js` and `./*.mjs` imports in the remote Rspack browser entry to absolute CDN URLs before creating the blob module
- Preserve the existing special handling for wasm, worker, and dependency imports

## Verification

- `pnpm exec rsbuild build`
- `pnpm exec rslint .`
- `pnpm exec oxfmt --check src/lib/bundle/core.ts`
- Verified locally that `v2.0.6` bundles successfully without the `Failed to resolve module specifier "./612.js"` error

## Related

fixes https://github.com/rstackjs/rspack-playground/issues/43